### PR TITLE
Comparing an instance of an S3::Object to nil (s3obj == nil) throws a NoMethodError

### DIFF
--- a/lib/s3/object.rb
+++ b/lib/s3/object.rb
@@ -17,7 +17,7 @@ module S3
     # of the objects are the same, and both have the same buckets (see
     # Bucket equality)
     def ==(other)
-      self.key == other.key and self.bucket == other.bucket
+      other.equal?(self) || (other.instance_of?(self.class) && self.key == other.key && self.bucket == other.bucket)
     end
 
     # Returns full key of the object: e.g. <tt>bucket-name/object/key.ext</tt>

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -40,6 +40,12 @@ class ObjectTest < Test::Unit::TestCase
       S3::Object.send(:new, nil, :key => "/images/pictures/test images/Lena not full.png")
     end
   end
+  
+  test "==" do
+    expected = false
+    actual = @object_lena == nil
+    assert_equal(expected, actual)
+  end
 
   test "full key" do
     expected = "images/Lena.png"


### PR DESCRIPTION
My commit fixes this issue. I took the same approach as ActiveRecord::Base#== to make the comparison method more robust. Test included.
