### PR TITLE
Enhance Temporary URL Generation

### DIFF
--- a/test/signature_test.rb
+++ b/test/signature_test.rb
@@ -140,4 +140,66 @@ class SignatureTest < Test::Unit::TestCase
     expected = "AWS 0PN5J17HBGZHT7JJ3X82:dxhSBHoI6eVSPcXJqEghlUzZMnY="
     assert_equal expected, actual
   end
+
+  test "temporary signature for object get" do
+    actual = S3::Signature.generate_temporary_url_signature(
+      :bucket => "johnsmith",
+      :resource => "photos/puppy.jpg",
+      :secret_access_key => "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+      :expires_at => 1175046589
+    )
+    expected = "gs6xNznrLJ4Bd%2B1y9pcy2HOSVeg%3D"
+    assert_equal expected, actual
+  end
+
+  test "temporary signature for object post" do
+    actual = S3::Signature.generate_temporary_url_signature(
+      :bucket => "johnsmith",
+      :resource => "photos/puppy.jpg",
+      :secret_access_key => "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+      :expires_at => 1175046589,
+      :method => :post
+    )
+    expected = "duIzwO2KTEMIlbSYbFFS86Wj0LI%3D"
+    assert_equal expected, actual
+  end
+
+  test "temporary signature for object put with headers" do
+    actual = S3::Signature.generate_temporary_url_signature(
+      :bucket => "johnsmith",
+      :resource => "photos/puppy.jpg",
+      :secret_access_key => "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+      :expires_at => 1175046589,
+      :method => :put,
+      :headers => {'x-amz-acl' => 'public-read'}
+    )
+    expected = "SDMxjIkOKIVR47nWfJ57UNPXxFM%3D"
+    assert_equal expected, actual
+  end
+
+  test "temporary signature for object delete" do
+    actual = S3::Signature.generate_temporary_url_signature(
+      :bucket => "johnsmith",
+      :resource => "photos/puppy.jpg",
+      :secret_access_key => "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+      :expires_at => 1175046589,
+      :method => :delete
+    )
+    expected = "5Vg7A4HxgS6tVCYzBx%2BkMR8sztY%3D"
+    assert_equal expected, actual
+  end
+
+  test "temporary url for object put with headers" do
+    actual = S3::Signature.generate_temporary_url(
+      :bucket => "johnsmith",
+      :resource => "photos/puppy.jpg",
+      :access_key => '0PN5J17HBGZHT7JJ3X82',
+      :secret_access_key => "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+      :expires_at => 1175046589,
+      :method => :put,
+      :headers => {'x-amz-acl' => 'public-read'}
+    )
+    expected = "http://s3.amazonaws.com/johnsmith/photos/puppy.jpg?AWSAccessKeyId=0PN5J17HBGZHT7JJ3X82&Expires=1175046589&Signature=SDMxjIkOKIVR47nWfJ57UNPXxFM%3D"
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
Jakub,

S3::Signature already has support for generating temporary url signatures. This commit enhances that existing functionality in two ways:

1) A new method, generate_temporary_url, to generate entire temporary urls instead of just their signatures.

2) Support for HTTP verbs besides GET and support for HTTP headers for the generated temporary url. This is useful if you'd like to generate a temporary URL to give to someone for uploading a file into your S3 bucket without having to make your bucket world-writable or give them your AWS credentials.

We're using a fork of your gem in the SteamCannon project (http://steamcannon.org) and it would be great to get this change pushed back upstream.

Thanks,
Ben
