### PR TITLE
Can't list more than 1000 objects from a bucket

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -104,6 +104,15 @@ module S3
     def list_bucket(options = {})
       response = bucket_request(:get, :params => options)
       objects_attributes = parse_list_bucket_result(response.body)
+      
+      # If there are more than 1000 objects S3 truncates listing
+      # and we need to request another listing for the remaining objects.
+      while parse_is_truncated(response.body)
+        marker = objects_attributes.last[:key]
+        response = bucket_request(:get, :params => options.merge(:marker => marker))
+        objects_attributes += parse_list_bucket_result(response.body)
+      end
+      
       objects_attributes.map { |object_attributes| Object.send(:new, self, object_attributes) }
     end
 

--- a/lib/s3/parser.rb
+++ b/lib/s3/parser.rb
@@ -44,5 +44,9 @@ module S3
       message = document.elements["Error/Message"].text
       [code, message]
     end
+    
+    def parse_is_truncated xml
+      rexml_document(xml).elements["ListBucketResult/IsTruncated"].text =='true'
+    end
   end
 end


### PR DESCRIPTION
Related to issue #12.

I'm patched Bucket#list_objects to keep requesting objects (through the _marker_ tag) until all objects are listed. Sorry for not giving tests...
