### PR TITLE
Fast access methods

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -94,6 +94,13 @@ module S3
       Proxy.new(lambda { list_bucket }, :owner => self, :extend => ObjectsExtension)
     end
 
+    # Returns the object with the given key. Does not check whether the
+    # object exists. But also does not issue any HTTP requests, so it's
+    # much faster than objects.find
+    def object(key)
+      Object.send(:new, self, :key => key)
+    end
+
     def inspect #:nodoc:
       "#<#{self.class}:#{name}>"
     end

--- a/lib/s3/service.rb
+++ b/lib/s3/service.rb
@@ -39,6 +39,13 @@ module S3
       Proxy.new(lambda { list_all_my_buckets }, :owner => self, :extend => BucketsExtension)
     end
 
+    # Returns the bucket with the given name. Does not check whether the
+    # bucket exists. But also does not issue any HTTP requests, so it's
+    # much faster than buckets.find
+    def bucket(name)
+      Bucket.send(:new, self, name)
+    end
+
     # Returns "http://" or "https://", depends on <tt>:use_ssl</tt>
     # value from initializer
     def protocol


### PR DESCRIPTION
These methods allow you to generate an url to a object without ever hitting the S3 service. These are useful if you know the bucket name and object key (because you have those saved in a local database) and you only want to generate a url to the objects.

I haven't tested it thoroughly...
