### PR TITLE
Add :replace option when pushing objects

### DIFF
--- a/lib/s3/object.rb
+++ b/lib/s3/object.rb
@@ -150,7 +150,7 @@ module S3
       headers[:content_disposition] = options[:content_disposition] if options[:content_disposition]
       headers[:cache_control] = options[:cache_control] if options[:cache_control]
       headers[:x_amz_copy_source] = full_key
-      headers[:x_amz_metadata_directive] = "REPLACE"
+      headers[:x_amz_metadata_directive] = options[:replace] == false ? "COPY" : "REPLACE"
       headers[:x_amz_copy_source_if_match] = options[:if_match] if options[:if_match]
       headers[:x_amz_copy_source_if_none_match] = options[:if_none_match] if options[:if_none_match]
       headers[:x_amz_copy_source_if_unmodified_since] = options[:if_modified_since] if options[:if_modified_since]

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -157,18 +157,18 @@ class ObjectTest < Test::Unit::TestCase
     actual = @object_lena.acl
     assert_equal expected, actual
   end
-  
+
   test "storage-class writer" do
     expected = nil
     actual = @object_lena.storage_class
     assert_equal expected, actual
-    
+
     assert @object_lena.storage_class = :standard
-    
+
     expected = "STANDARD"
     actual = @object_lena.storage_class
     assert_equal expected, actual
-    
+
     assert @object_lena.storage_class = :reduced_redundancy
 
     expected = "REDUCED_REDUNDANCY"
@@ -176,10 +176,19 @@ class ObjectTest < Test::Unit::TestCase
     assert_equal expected, actual
   end
 
-  test "copy" do
+  test "replace" do
     @bucket_images.expects(:bucket_request).with(:put, :path => "Lena-copy.png", :headers => { :x_amz_acl => "public-read", :content_type => "application/octet-stream", :x_amz_copy_source => "images/Lena.png", :x_amz_metadata_directive => "REPLACE" }).returns(@response_xml)
 
     new_object = @object_lena.copy(:key => "Lena-copy.png")
+
+    assert_equal "Lena-copy.png", new_object.key
+    assert_equal "Lena.png", @object_lena.key
+  end
+
+  test "copy" do
+    @bucket_images.expects(:bucket_request).with(:put, :path => "Lena-copy.png", :headers => { :x_amz_acl => "public-read", :content_type => "application/octet-stream", :x_amz_copy_source => "images/Lena.png", :x_amz_metadata_directive => "COPY" }).returns(@response_xml)
+
+    new_object = @object_lena.copy(:key => "Lena-copy.png", :replace => false)
 
     assert_equal "Lena-copy.png", new_object.key
     assert_equal "Lena.png", @object_lena.key


### PR DESCRIPTION
Allow to copy objects instead of replacing, I think this should be the default but didn't want to change it and break people code already using it.
