### PR TITLE
Add support for 'Access-Control-Allow-Origin' custom header to fix FF Cross-Site web fonts and other objects

### DIFF
--- a/lib/s3/object.rb
+++ b/lib/s3/object.rb
@@ -5,7 +5,7 @@ module S3
     include Parser
     extend Forwardable
 
-    attr_accessor :content_type, :content_disposition, :content_encoding, :cache_control
+    attr_accessor :content_type, :content_disposition, :content_encoding, :cache_control, :access_control_allow_origin
     attr_reader :last_modified, :etag, :size, :bucket, :key, :acl, :storage_class
     attr_writer :content
 
@@ -230,6 +230,7 @@ module S3
       headers[:content_encoding] = @content_encoding if @content_encoding
       headers[:content_disposition] = @content_disposition if @content_disposition
       headers[:cache_control] = @cache_control if @cache_control
+      headers[:access_control_allow_origin] = @access_control_allow_origin if @access_control_allow_origin
       headers
     end
 


### PR DESCRIPTION
Add support for 'Access-Control-Allow-Origin' custom header to fix FF Cross-Site web fonts and other objects
