### PR TITLE
Fixing URI encoding issues

### DIFF
--- a/extra/s3_paperclip.rb
+++ b/extra/s3_paperclip.rb
@@ -47,13 +47,13 @@ module Paperclip
           @bucket = @service.buckets.build(@bucket_name)
         end
         Paperclip.interpolates(:s3_alias_url) do |attachment, style|
-          "#{attachment.s3_protocol}://#{attachment.s3_host_alias}/#{attachment.path(style).gsub(%r{^/}, "")}"
+          "#{attachment.s3_protocol}://#{attachment.s3_host_alias}/#{Paperclip::Storage::S3.encode_path(attachment.path(style)).gsub(%r{^/}, "")}"
         end
         Paperclip.interpolates(:s3_path_url) do |attachment, style|
-          "#{attachment.s3_protocol}://s3.amazonaws.com/#{attachment.bucket_name}/#{attachment.path(style).gsub(%r{^/}, "")}"
+          "#{attachment.s3_protocol}://s3.amazonaws.com/#{attachment.bucket_name}/#{Paperclip::Storage::S3.encode_path(attachment.path(style)).gsub(%r{^/}, "")}"
         end
         Paperclip.interpolates(:s3_domain_url) do |attachment, style|
-          "#{attachment.s3_protocol}://#{attachment.bucket_name}.s3.amazonaws.com/#{attachment.path(style).gsub(%r{^/}, "")}"
+          "#{attachment.s3_protocol}://#{attachment.bucket_name}.s3.amazonaws.com/#{Paperclip::Storage::S3.encode_path(attachment.path(style)).gsub(%r{^/}, "")}"
         end
       end
 
@@ -107,6 +107,15 @@ module Paperclip
           file = nil
         end
         file
+      end
+
+      # Encodes all characters except forward-slash (/) and explicitly legal URL characters
+      def self.encode_path(path)
+        URI.encode(path, /[^#{URI::REGEXP::PATTERN::UNRESERVED}\/]/)
+      end
+
+      def encoded_path(style)
+        Paperclip::Storage::S3.encode_path(path(style))
       end
 
       def flush_writes #:nodoc:

--- a/lib/s3/connection.rb
+++ b/lib/s3/connection.rb
@@ -60,13 +60,16 @@ module S3
       body = options.fetch(:body, nil)
       params = options.fetch(:params, {})
       headers = options.fetch(:headers, {})
+      
+      # Must be done before adding params
+      # Encodes all characters except forward-slash (/) and explicitly legal URL characters
+      path = URI.escape(path, /[^#{URI::REGEXP::PATTERN::UNRESERVED}\/]/)
 
       if params
         params = params.is_a?(String) ? params : self.class.parse_params(params)
         path << "?#{params}"
       end
 
-      path = URI.escape(path)
       request = Request.new(@chunk_size, method.to_s.upcase, !!body, method.to_s.upcase != "HEAD", path)
 
       headers = self.class.parse_headers(headers)


### PR DESCRIPTION
Properly encode paths with reserved URI characters such as [ and ]. The default URI.escape does not encode these. Now everything except / is encoded. Also properly encoding generated URLs from attachments. Any filename in any encoding (not containing a /) should now work.

Further explanation here:

https://github.com/qoobaa/s3/issues/36
