### PR TITLE
Support for setting cache-control header in paperclip models

### DIFF
--- a/extra/s3_paperclip.rb
+++ b/extra/s3_paperclip.rb
@@ -5,6 +5,7 @@
 #
 #   has_attached_file :image,
 #                     :s3_host_alias => "bucket.domain.tld",
+#                     :s3_headers => { :cache_control => 10.years.from_now.httpdate },
 #                     :url => ":s3_alias_url",
 #                     :styles => {
 #                       :medium => "300x300>",
@@ -128,6 +129,7 @@ module Paperclip
             object.acl = @s3_permissions
             object.storage_class = @s3_storage_class
             object.content_type = instance_read(:content_type)
+            object.cache_control = @s3_headers[:cache_control]
             object.content_disposition = @s3_headers[:content_disposition]
             object.content_encoding = @s3_headers[:content_encoding]
             object.save


### PR DESCRIPTION
Hi qoobaa,

thanks for writing the s3 gem, we are using it extensively in our environment.

This is just a tiny patch adding support for setting cache-control metadata in paperclip models, something that the gem supports, but the included initializer file doesn't.

Regards
Ralph
