### PR TITLE
Fixes #49

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -121,8 +121,16 @@ module S3
       # If there are more than 1000 objects S3 truncates listing
       # and we need to request another listing for the remaining objects.
       while parse_is_truncated(response.body)
-        marker = objects_attributes.last[:key]
-        response = bucket_request(:get, :params => options.merge(:marker => marker))
+      	next_request_options = {
+      		:marker => objects_attributes.last[:key]
+      	}
+      	
+      	if options[:max_keys]
+      		break if objects_attributes.length >= options[:max_keys]
+      		next_request_options[:max_keys] = options[:max_keys] - objects_attributes.length
+      	end
+      		
+        response = bucket_request(:get, :params => options.merge(next_request_options))
         objects_attributes += parse_list_bucket_result(response.body)
       end
 


### PR DESCRIPTION
Respects max_keys if specified in a bucket_list operation. Fixes #49.

If no max_keys is specified, it will return the entire rest of the contents of the bucket.
If a max_keys is specified that is greater then s3 will return (currently 1000), then it will continue to make requests until the proper number of items has been returned.

I'd add a test, but this kind of thing needs a real connection to test against, not a mock.

I'd appreciate a pull and rebuild of the gem.
