### PR TITLE
Ruby 1.9.3-preview1 support

### DIFF
--- a/lib/s3/parser.rb
+++ b/lib/s3/parser.rb
@@ -3,7 +3,7 @@ module S3
     include REXML
 
     def rexml_document(xml)
-      xml.force_encoding(Encoding::UTF_8) if xml.respond_to? :force_encoding
+      xml.force_encoding(::Encoding::UTF_8) if xml.respond_to? :force_encoding
       Document.new(xml)
     end
 


### PR DESCRIPTION
Ruby 1.9.3-preview1 forces us to specify when a namespace is defined at the root level of namespaces (at least if a module is included in the current module). Damn, this is hard to explain. All unit tests now pass.

Related to [issue #52](https://github.com/qoobaa/s3/issues/52)
