### PR TITLE
Fix issue with nil content

### DIFF
--- a/lib/s3/connection.rb
+++ b/lib/s3/connection.rb
@@ -199,6 +199,8 @@ module S3
         if response.body
           doc = Document.new response.body
           send_request(doc.elements["Error"].elements["Endpoint"].text, request, true)
+        elsif (location = response['location'])
+          send_request(URI.parse(location).host, request, true)
         end
       else
         handle_response(response)

--- a/lib/s3/object.rb
+++ b/lib/s3/object.rb
@@ -7,7 +7,6 @@ module S3
 
     attr_accessor :content_type, :content_disposition, :content_encoding, :cache_control
     attr_reader :last_modified, :etag, :size, :bucket, :key, :acl, :storage_class, :metadata
-    attr_writer :content
 
     def_instance_delegators :bucket, :name, :service, :bucket_request, :vhost?, :host, :path_prefix
     def_instance_delegators :service, :protocol, :port, :secret_access_key
@@ -70,11 +69,15 @@ module S3
       false
     end
 
+    def content=(value)
+      @content = value
+      @has_content = true
+    end
+
     # Downloads the content of the object, and caches it. Pass true to
     # clear the cache and download the object again.
     def content(reload = false)
-      return @content if defined?(@content) and not reload
-      get_object
+      get_object if reload or not @has_content
       @content
     end
 
@@ -172,6 +175,7 @@ module S3
     def get_object(options = {})
       response = object_request(:get, options)
       parse_headers(response)
+      self.content = response.body
     end
 
     def object_headers(options = {})
@@ -246,7 +250,6 @@ module S3
         self.size = response["content-range"].sub(/[^\/]+\//, "").to_i
       else
         self.size = response["content-length"]
-        self.content = response.body
       end
     end
   end


### PR DESCRIPTION
After upgrading to 0.3.11, this was always returning nil for me:

```ruby
bucket.objects.find("somekey").content
```

The reason was that `find` would cause `Object#parse_headers` to read a HEAD response and then set the content from `response.body`. But a HEAD always returns an empty body. So when you later check `defined(@content)`, that returns a non-false value even though `@content` is `nil`.

By the way, you might want to look into the `vcr` gem in order to write tests against S3 (without actually needing S3).