### PR TITLE
dont assume s3.amazonaws.com in Signature build

### DIFF
--- a/lib/s3/signature.rb
+++ b/lib/s3/signature.rb
@@ -209,7 +209,7 @@ module S3
       # requests that don't address a bucket, do nothing. For more
       # information on virtual hosted-style requests, see Virtual
       # Hosting of Buckets.
-      bucket_name = host.sub(/\.?s3\.amazonaws\.com\Z/, "")
+      bucket_name = host.sub(/\.?#{S3::HOST}\Z/, "")
       string << "/#{bucket_name}" unless bucket_name.empty?
 
       # 3. Append the path part of the un-decoded HTTP Request-URI,


### PR DESCRIPTION
Building authz signature with a vhosted bucket name failed if a proxy or
non-amazon host was used

This assumes one would override the hostname at `S3::HOST`
