### PR TITLE
Avoiding the double-reading problem of Net::HTTP

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -200,9 +200,9 @@ module S3
       @name = name
     end
 
-    def bucket_request(method, options = {})
+    def bucket_request(method, options = {}, &block)
       path = "#{path_prefix}#{options[:path]}"
-      service_request(method, options.merge(:host => host, :path => path))
+      service_request(method, options.merge(:host => host, :path => path), &block)
     end
 
     def name_valid?(name)

--- a/lib/s3/connection.rb
+++ b/lib/s3/connection.rb
@@ -53,7 +53,7 @@ module S3
     #
     # ==== Returns
     # Net::HTTPResponse object -- response from the server
-    def request(method, options)
+    def request(method, options, &block)
       host = options.fetch(:host, HOST)
       path = options.fetch(:path)
       body = options.fetch(:body, nil)
@@ -85,7 +85,7 @@ module S3
         request.content_length = body.respond_to?(:lstat) ? body.stat.size : body.size
       end
 
-      send_request(host, request)
+      send_request(host, request, &block)
     end
 
     # Helper function to parser parameters and create single string of
@@ -173,8 +173,8 @@ module S3
       http
     end
 
-    def send_request(host, request, skip_authorization = false)
-      response = http(host).start do |http|
+    def send_request(host, request, skip_authorization = false, &block)
+      http(host).start do |http|
         host = http.address
 
         request["Date"] ||= Time.now.httpdate
@@ -191,16 +191,18 @@ module S3
                                                         :secret_access_key => secret_access_key)
         end
 
-        http.request(request)
-      end
-
-      if response.code.to_i == 307
-        if response.body
-          doc = Document.new response.body
-          send_request(doc.elements["Error"].elements["Endpoint"].text, request, true)
+        http.request(request) do |response|
+          if response.code.to_i == 307
+            if response.body
+              doc = Document.new response.body
+              return send_request(doc.elements["Error"].elements["Endpoint"].text, request, true, &block)
+            end
+          else
+            result = handle_response(response)
+            yield result unless block.nil?
+            return result
+          end
         end
-      else
-        handle_response(response)
       end
     end
 

--- a/lib/s3/object.rb
+++ b/lib/s3/object.rb
@@ -187,8 +187,9 @@ module S3
     end
 
     def get_object(options = {}, &block)
-      response = object_request(:get, options)
-      parse_headers(response, &block)
+      object_request(:get, options) do |response|
+        parse_headers(response, &block)
+      end
     end
 
     def object_headers(options = {})
@@ -220,8 +221,8 @@ module S3
       self.cache_control = options[:cache_control]
     end
 
-    def object_request(method, options = {})
-      bucket_request(method, options.merge(:path => key))
+    def object_request(method, options = {}, &block)
+      bucket_request(method, options.merge(:path => key), &block)
     end
 
     def last_modified=(last_modified)

--- a/lib/s3/service.rb
+++ b/lib/s3/service.rb
@@ -70,8 +70,8 @@ module S3
       names.map { |name| Bucket.send(:new, self, name) }
     end
 
-    def service_request(method, options = {})
-      connection.request(method, options.merge(:path => "/#{options[:path]}"))
+    def service_request(method, options = {}, &block)
+      connection.request(method, options.merge(:path => "/#{options[:path]}"), &block)
     end
 
     def connection

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -12,8 +12,8 @@ class ConnectionTest < Test::Unit::TestCase
     @response_error = Net::HTTPInternalServerError.new("1.1", "500", "Internal Server Error")
     @response_temporary_redirect = Net::HTTPInternalServerError.new("1.1", "307", "Temporary Redirect")
     @connection.stubs(:http).returns(@http_request)
-
-    @http_request.stubs(:start).returns(@response_ok)
+    @http_request.stubs(:start).yields(@http_request)
+    @http_request.stubs(:request).yields(@response_ok)
   end
 
   test "handle response not modify response when ok" do
@@ -36,7 +36,7 @@ class ConnectionTest < Test::Unit::TestCase
     </Error>
     EOFakeBody
 
-    @http_request.stubs(:start).returns(@response_not_found)
+    @http_request.stubs(:request).yields(@response_not_found)
     @response_not_found.stubs(:body).returns(response_body)
 
     assert_raise S3::Error::NoSuchBucket do
@@ -49,7 +49,7 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   test "handle response throws standard exception when error" do
-    @http_request.stubs(:start).returns(@response_error)
+    @http_request.stubs(:request).yields(@response_error)
     @response_error.stubs(:body)
     assert_raise S3::Error::ResponseError do
       response = @connection.request(
@@ -174,7 +174,7 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   test "response.body is nil on TemporaryRedirect" do
-    @http_request.stubs(:start).returns(@response_temporary_redirect)
+    @http_request.stubs(:request).yields(@response_temporary_redirect)
     @response_temporary_redirect.stubs(:body).returns(nil)
 
     assert_nothing_raised do

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -121,7 +121,7 @@ class ObjectTest < Test::Unit::TestCase
   end
 
   test "content and parse headers" do
-    @object_lena.expects(:object_request).with(:get, {}).returns(@response_binary)
+    @object_lena.expects(:object_request).with(:get, {}).yields(@response_binary)
 
     expected = /test/n
     actual = @object_lena.content(true)
@@ -135,7 +135,7 @@ class ObjectTest < Test::Unit::TestCase
   end
 
   test "streaming" do
-    @object_lena.expects(:object_request).with(:get, {}).returns(@response_binary)
+    @object_lena.expects(:object_request).with(:get, {}).yields(@response_binary)
 
     expected = /test/n
     io = StringIO.new


### PR DESCRIPTION
When issuing a request with Net::HTTP, you can provide a block in which you may read the
body chunk by chunk. However, it will continue to read the remainder fo the request body
afterwards, and so you're left needing to do all of your chunked work within the context
of the block.

It's a little ugly, but the block just has to be propagated forwards quite a ways.
