### PR TITLE
Use OpenSSL::Digest instead of OpenSSL::Digest::Digest

### DIFF
--- a/lib/s3/signature.rb
+++ b/lib/s3/signature.rb
@@ -135,7 +135,7 @@ module S3
       string_to_sign << canonicalized_amz_headers
       string_to_sign << canonicalized_resource
 
-      digest = OpenSSL::Digest::Digest.new("sha1")
+      digest = OpenSSL::Digest.new("sha1")
       hmac = OpenSSL::HMAC.digest(digest, secret_access_key, string_to_sign)
       base64 = Base64.encode64(hmac)
       base64.chomp


### PR DESCRIPTION
Even though there has been no deprecation warning until now OpenSSL::Digest::Digest has only been
provided for backwards combability since Ruby 1.8

See https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
Deprecation warning added with https://github.com/ruby/ruby/pull/446
