### PR TITLE
SSL services shouldn't use vhost.

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -94,7 +94,7 @@ module S3
     # name. If the bucket contains characters like underscore it can't
     # be used as +VHOST+ (e.g. <tt>bucket_name.s3.amazonaws.com</tt>)
     def vhost?
-      "#@name.#{HOST}" =~ /\A#{URI::REGEXP::PATTERN::HOSTNAME}\Z/
+      !service.use_ssl && "#@name.#{HOST}" =~ /\A#{URI::REGEXP::PATTERN::HOSTNAME}\Z/
     end
 
     # Returns host name of the bucket according (see #vhost? method)

--- a/test/bucket_test.rb
+++ b/test/bucket_test.rb
@@ -2,8 +2,9 @@ require "test_helper"
 
 class BucketTest < Test::Unit::TestCase
   def setup
-    @bucket_vhost = S3::Bucket.send(:new, nil, "Data-Bucket")
-    @bucket_path = S3::Bucket.send(:new, nil, "Data_Bucket")
+    @bucket_vhost = S3::Bucket.send(:new, S3::Service.new(access_key_id: 'test', secret_access_key: 'secret'), "Data-Bucket")
+    @bucket_path = S3::Bucket.send(:new, S3::Service.new(access_key_id: 'test', secret_access_key: 'secret'), "Data_Bucket")
+    @secure_bucket = S3::Bucket.send(:new, S3::Service.new(access_key_id: 'test', secret_access_key: 'secret', use_ssl: true), "Data-Secured")
     @bucket = @bucket_vhost
 
     @bucket_location = "EU"
@@ -97,6 +98,10 @@ class BucketTest < Test::Unit::TestCase
 
     expected = "s3.amazonaws.com"
     actual = @bucket_path.host
+    assert_equal expected, actual
+
+    expected = "s3.amazonaws.com"
+    actual = @secure_bucket.host
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
At least chrome won't show content of from S3 through SSL if the url
uses a vhost since the certificate is a wildcard (*.s3.amazon.com).
Instead, SSL'ed service should just use the normal host to make sure no
warning are raised.

Tests have been modified to include this change
