### PR TITLE
Raise ArgumentError if required options are falsey

### DIFF
--- a/lib/s3/service.rb
+++ b/lib/s3/service.rb
@@ -25,6 +25,12 @@ module S3
     # * <tt>:timeout</tt> - Timeout to use by the Net::HTTP object
     #   (60 by default)
     def initialize(options)
+      # The keys for these required options might exist in the options hash, but
+      # they might be set to something like `nil`. If this is the case, we want
+      # to fail early.
+      raise ArgumentError, "Missing :access_key_id." if !options[:access_key_id]
+      raise ArgumentError, "Missing :secret_access_key." if !options[:secret_access_key]
+
       @access_key_id = options.fetch(:access_key_id)
       @secret_access_key = options.fetch(:secret_access_key)
       @use_ssl = options.fetch(:use_ssl, false)


### PR DESCRIPTION
I was occasionally seeing "no implicit conversion of nil into String
(TypeError)" when calling buckets.find. This was happening all the way
in the `digest` call in the Signature class because the
`secret_access_key` had been set to `nil`. Since this value is set at
initialization time, we can be proactive with a helpful error message
when this happens.

Fixes #107