### PR TITLE
Add use_ssl flag to Signature generate_temporary_url method.

### DIFF
--- a/lib/s3/signature.rb
+++ b/lib/s3/signature.rb
@@ -85,18 +85,21 @@ module S3
     #   to use when requesting the resource
     # * <tt>:add_bucket_to_host</tt> - Use in case of virtual-host style,
     #   defaults to false
+    # * <tt>:use_ssl</tt> - If true generates the temporary url with 'https'
+    #   as opposed to 'http'
     def self.generate_temporary_url(options)
       bucket = options[:bucket]
       resource = options[:resource]
       access_key = options[:access_key]
       expires = options[:expires_at].to_i
+      protocol = (options[:use_ssl] ? 'https://' : 'http://')
       host = S3.host
 
       if options[:add_bucket_to_host]
         host = bucket + '.' + host
-        url  = "http://#{host}/#{resource}"
+        url  = "#{protocol}#{host}/#{resource}"
       else
-        url = "http://#{host}/#{bucket}/#{resource}"
+        url = "#{protocol}#{host}/#{bucket}/#{resource}"
       end
 
       options[:host] = host

--- a/test/signature_test.rb
+++ b/test/signature_test.rb
@@ -151,7 +151,7 @@ class SignatureTest < Test::Unit::TestCase
     expected = "gs6xNznrLJ4Bd%2B1y9pcy2HOSVeg%3D"
     assert_equal expected, actual
   end
-  
+
   test "temporary signature for object get with non-unreserved URI characters" do
     actual = S3::Signature.generate_temporary_url_signature(
       :bucket => "johnsmith",
@@ -209,6 +209,18 @@ class SignatureTest < Test::Unit::TestCase
       :add_bucket_to_host => true
     )
     expected = "http://johnsmith.s3.amazonaws.com/photos/puppy.jpg?AWSAccessKeyId=&Expires=1175046589&Signature=gs6xNznrLJ4Bd%2B1y9pcy2HOSVeg%3D"
+    assert_equal expected, actual
+  end
+
+  test "temporary url for object get using ssl" do
+    actual = S3::Signature.generate_temporary_url(
+      :bucket => "johnsmith",
+      :resource => "photos/puppy.jpg",
+      :secret_access_key => "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+      :expires_at => 1175046589,
+      :use_ssl => true
+    )
+    expected = "https://s3.amazonaws.com/johnsmith/photos/puppy.jpg?AWSAccessKeyId=&Expires=1175046589&Signature=gs6xNznrLJ4Bd%2B1y9pcy2HOSVeg%3D"
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
A little cleaner than using gsub, and allowed me to get around mixed-content warnings.