### PR TITLE
Issue #125: Object#content now aware of @content initilization

### DIFF
--- a/lib/s3/object.rb
+++ b/lib/s3/object.rb
@@ -84,7 +84,7 @@ module S3
     # Downloads the content of the object, and caches it. Pass true to
     # clear the cache and download the object again.
     def content(reload = false)
-      return @content if defined?(@content) and not reload
+      return @content unless reload or @content.nil?
       get_object
       @content
     end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -146,7 +146,9 @@ class ObjectTest < Test::Unit::TestCase
   end
 
   test "retrieve dont set content" do
-    @object_lena.send(:remove_instance_variable, :@content)
+    # Simulates S3::Object#new's initilization of @content, eg
+    # as called by ObjectsExtension#build or BucketsExtension#build
+    @object_lena.content = nil
 
     @response_binary.stubs(:body).returns(nil)
     @object_lena.expects(:object_request).with(:head, {}).returns(@response_binary)


### PR DESCRIPTION
More details in #125:

With fc4d193 a change was made to S3::Object#initialize which
initializes the value of `@content` to `nil`. In Ruby this is enough to
satisfy `Object#defined?` (as `instance-variable`). This had an
unintended consequence of the `content(reload = false)` method always
return `nil` unless `reload = true`.

This commit will make the method more aware and address the issue in the
existing test suite.