### PR TITLE
Added support for custom ports

### DIFF
--- a/lib/s3.rb
+++ b/lib/s3.rb
@@ -28,5 +28,9 @@ module S3
     def host
       @host ||= "s3.amazonaws.com"
     end
+    attr_writer :port
+    def port
+      @port
+    end
   end
 end

--- a/lib/s3/connection.rb
+++ b/lib/s3/connection.rb
@@ -157,7 +157,7 @@ module S3
     private
 
     def port
-      use_ssl ? 443 : 80
+      S3.port ? S3.port : (use_ssl ? 443 : 80)
     end
 
     def proxy_settings

--- a/lib/s3/service.rb
+++ b/lib/s3/service.rb
@@ -61,10 +61,10 @@ module S3
       use_ssl ? "https://" : "http://"
     end
 
-    # Returns 443 or 80, depends on <tt>:use_ssl</tt> value from
+    # Returns a custom port, 443 or 80, depends on <tt>:use_ssl</tt> value from
     # initializer
     def port
-      use_ssl ? 443 : 80
+      S3.port ? S3.port : (use_ssl ? 443 : 80)
     end
 
     def inspect #:nodoc:


### PR DESCRIPTION
Hi.
I'm using a Ceph cluster with a custom port (neither 80 nor 443) and needed to add support.