### PR TITLE
Add InvalidObjectState exception class

### DIFF
--- a/lib/s3/exceptions.rb
+++ b/lib/s3/exceptions.rb
@@ -63,6 +63,7 @@ module S3
     class InvalidBucketName < ResponseError; end
     class InvalidDigest < ResponseError; end
     class InvalidLocationConstraint < ResponseError; end
+    class InvalidObjectState < ResponseError; end
     class InvalidPayer < ResponseError; end
     class InvalidPolicyDocument < ResponseError; end
     class InvalidRange < ResponseError; end


### PR DESCRIPTION
We can get this kind of exception when there's an object in a bucket has been moved to Glacier, for example, and attempt `S3::Object#content`.